### PR TITLE
Remove celery from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 # pip packages not in requirements files
 uwsgi
-# celery 4.4.7 has a bug https://github.com/celery/celery/issues/6370
-celery==4.4.6


### PR DESCRIPTION
celery has been locked to v4.4.6 in casepro v1.4.4